### PR TITLE
force download so download doesn't fail on previously downloaded file

### DIFF
--- a/DockstoreRunner.py
+++ b/DockstoreRunner.py
@@ -330,7 +330,7 @@ class DockstoreRunner:
                 #create list of individual command 'words' for input to run commmand function
                 self.run_command(cmd, self.MAX_ATTEMPTS, self.DELAY_IN_SECONDS)
 
-                cmd = "icgc-storage-client download --output-dir {} --object-id {} --output-layout bundle".format(self.tmp_dir, file_uuid)
+                cmd = "icgc-storage-client download --output-dir {} --object-id {} --output-layout bundle --force".format(self.tmp_dir, file_uuid)
                 #create list of individual command 'words' for input to run commmand function
                 self.run_command(cmd, self.MAX_ATTEMPTS, self.DELAY_IN_SECONDS)
 


### PR DESCRIPTION
force download so download doesn't fail on previously downloaded file
In some cases the download client will download more than one file
even when only one file uuid is specified. We have seen this when
requesting download of a VCF file and the client also downloads
the VCF index file even though we passed the file uuid for only the
VDF (non index) file