### PR TITLE
record the location of the Dockstore jar file in an environment var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,8 @@ RUN chmod a+x /usr/local/bin/DockstoreRunner.py
 #set the following env var so dockstore does not question
 #the fact that we are running as root
 ENV DOCKSTORE_ROOT 1
+#Indicate to Dockstore where the dockstore jar file is located 
+ENV DOCKSTORE_HOME /root/.dockstore
 
 #container must run as root in order to access docker.sock on the host
 #becuase ubuntu is not a member of the host's docker.sock docker group

--- a/Dockstore.cwl
+++ b/Dockstore.cwl
@@ -24,7 +24,7 @@ dct:creator:
 
 requirements:
   - class: DockerRequirement
-    dockerPull: "quay.io/ucsc_cgl/dockstore-tool-runner:1.0.24"
+    dockerPull: "quay.io/ucsc_cgl/dockstore-tool-runner:1.0.25"
 
 hints:
   - class: ResourceRequirement


### PR DESCRIPTION
record the location of the Dockstore jar file in an environment var so that the Dockstore client can find it.  The Dockstore client will try to download the Dockstore jar file if the env var HOME is set to a different location than where .dockstore/self_installs/<jar file> is located.